### PR TITLE
[IR-618]Update simple-service version to 0.0.2 and add repeater configuration in deployment

### DIFF
--- a/charts/commix/Chart.yaml
+++ b/charts/commix/Chart.yaml
@@ -7,5 +7,5 @@ keywords:
 version: 0.0.4
 dependencies:
 - name: simple-service
-  version: 0.0.1
+  version: 0.1.0
   repository: "file://../../simple-service"

--- a/simple-service/Chart.yaml
+++ b/simple-service/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: simple-service
 description: A simple service with customizable name and port
 type: application
-version: 0.0.1
-appVersion: "0.0.1"
+version: 0.1.0
+appVersion: "0.1.0"

--- a/simple-service/templates/deployment.yaml
+++ b/simple-service/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       labels:
         app: {{ .Release.Name }}
     spec:
+      hostAliases:
+        - ip: "127.0.0.1"
+          hostnames:
+            - "target.local"
       containers:
         - name: app
           image: {{ .Values.application.image }}
@@ -29,5 +33,31 @@ spec:
 {{ toYaml .Values.application.livenessProbe | indent 12 }}
           readinessProbe:
 {{ toYaml .Values.application.readinessProbe | indent 12 }}
-      imagePullSecrets:
+        {{- if and .Values.repeaterIDs .Values.token .Values.cluster }}
+        {{- range $index, $repeaterIDs := .Values.repeaterIDs }}
+        - name: repeater-{{ $index }}
+          image: brightsec/cli{{ if $.Values.repeaterImageTag }}:{{ $.Values.repeaterImageTag }}{{ else }}:latest{{ end }}
+          command: ["bright-cli", "repeater"]
+          args:
+            - "--token=$(TOKEN)"
+            - "--id=$(REPEATER_ID)"
+            - "--cluster=$(CLUSTER)"
+            - "--timeout=$(TIMEOUT)"
+            - "--log-level=verbose"
+          resources:
+            requests:
+              cpu: 200m
+              memory: 100Mi
+          env:
+            - name: REPEATER_ID
+              value: "{{ $repeaterIDs }}"
+            - name: TOKEN
+              value: "{{ $.Values.token }}"
+            - name: CLUSTER
+              value: "{{ $.Values.cluster }}"
+            - name: TIMEOUT
+              value: "{{ $.Values.timeout | default "30000" }}"
+        {{- end }}
+        {{- end }}
+      imagePullSecrets:      
         - name: pull-ghcr-io

--- a/simple-service/templates/ingress.yaml
+++ b/simple-service/templates/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-cf-prod
     {{ end }}
 spec:
+  ingressClassName: nginx
   tls:
     - hosts:
         - {{ .Release.Name }}.k3s.brokencrystals.nexploit.app 

--- a/simple-service/values.yaml
+++ b/simple-service/values.yaml
@@ -11,3 +11,8 @@ application:
       memory: 500Mi
     limits:
       memory: 1024Mi
+  repeaterIDs: ""
+  token: ""
+  cluster: ""
+  timeout: "30000"
+  repeaterImageTag: ""


### PR DESCRIPTION
- Added simple-service v2 that has repeater code in it
- Fixed ingress class
Command to test (do it inside commix app):
helm upgrade --install test . --namespace distributor --set simple-service.timeout=40000 --set simple-service.token="token" --set simple-service.cluster="https://hotel.playground.brightsec.com/" --set simple-service.repeaterID[0]="repeaterID1" --set simple-service.repeaterID[1]="repeaterID1"