### PR TITLE
feature: add ollama service to broken crystals

### DIFF
--- a/charts/brokencrystals/Chart.yaml
+++ b/charts/brokencrystals/Chart.yaml
@@ -4,7 +4,7 @@ description: |
   Benchmark application that uses modern technologies and implements a set of
   common security vulnerabilities
 type: application
-version: 0.1.23
+version: 0.1.24
 icon: https://raw.githubusercontent.com/NeuraLegion/brokencrystals/stable/public/public/assets/img/logo.png
 keywords:
   - brokencrystals

--- a/charts/brokencrystals/templates/deployment.yaml
+++ b/charts/brokencrystals/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
             - "proxy"
             - "repeater"
             - "db"
+            - "ollama"
             - "brokencrystals.local"
       containers:
         - name: postgres
@@ -168,6 +169,10 @@ spec:
               value: "https://raw.githubusercontent.com/NeuraLegion/brokencrystals/stable/config/keys/x509.crt"
             - name: KEYCLOAK_SERVER_URI
               value: "http://keycloak:8080/auth"
+            {{- if .Values.useOllama }}
+            - name: OLLAMA_SERVICE_URL
+              value: "http://ollama:11434"
+            {{- end }}
             {{ $configmap := (lookup "v1" "ConfigMap" .Release.Namespace .Values.clusterConfigMap) }}
             {{- if $configmap}}
           envFrom:
@@ -198,6 +203,34 @@ spec:
         {{- if .Values.useMailcatcher }}
         - name: mailcatcher
           image: sj26/mailcatcher
+        {{- end }}
+
+        {{- if .Values.useOllama }}
+        - name: ollama
+          image: brightsec/brokencrystals-ollama:smollm135m
+          ports:
+            - containerPort: 11434
+          resources:
+            requests:
+              cpu: 200m
+              memory: 200Mi
+            limits:
+              cpu: 1
+              memory: 2Gi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 11434
+              scheme: HTTP
+            initialDelaySeconds: 120
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 11434
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
         {{- end }}
 
         {{- if and $token $cluster (gt (len $repeaterIDs) 0) }}

--- a/charts/brokencrystals/templates/deployment.yaml
+++ b/charts/brokencrystals/templates/deployment.yaml
@@ -212,11 +212,11 @@ spec:
             - containerPort: 11434
           resources:
             requests:
-              cpu: 200m
-              memory: 200Mi
+              cpu: "100m"
+              memory: "350Mi"
             limits:
-              cpu: 1
-              memory: 2Gi
+              cpu: "2000m"
+              memory: "1Gi"
           livenessProbe:
             httpGet:
               path: /

--- a/charts/brokencrystals/templates/service.yaml
+++ b/charts/brokencrystals/templates/service.yaml
@@ -33,3 +33,17 @@ spec:
   - protocol: TCP
     port: 1080
     targetPort: 1080
+---
+{{- if .Values.useOllama }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-ollama
+spec:
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+  - protocol: TCP
+    port: 11434
+    targetPort: 11434
+{{- end }}

--- a/charts/brokencrystals/values.yaml
+++ b/charts/brokencrystals/values.yaml
@@ -8,6 +8,7 @@ cluster: null
 timeout: null
 clusterConfigMap: "brokencrystals-config"
 useMailcatcher: false
+useOllama: false
 ingress:
   url: null
   cert: ""


### PR DESCRIPTION
Added new LLM service to Broken Crystals.
Ollama is running one of the smallest possible models [https://ollama.com/library/smollm:135m](https://ollama.com/library/smollm:135m )
In this configuration Ollama requires:
- memory ~350m on simple requests. I expect ~500m-1GB maximum on complex requests
- cpu - as much as it can :) no cpu consuption while idle. Response time with 1 cpu was ~100sec, with 2 cpus ~50sec. So I set 2cpus as upper limit for now 

[SET-1901](https://brightsec.atlassian.net/browse/SET-1901)

[SET-1901]: https://brightsec.atlassian.net/browse/SET-1901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ