### PR TITLE
fix(juice-shop): Update the Juice Shop chart to run the latest version

### DIFF
--- a/charts/juice-shop/Chart.yaml
+++ b/charts/juice-shop/Chart.yaml
@@ -6,7 +6,7 @@ description: |
 type: application
 keywords:
 - juiceshop
-version: 0.0.6
+version: 0.0.7
 dependencies:
 - name: simple-service
   version: 0.0.1

--- a/charts/juice-shop/values.yaml
+++ b/charts/juice-shop/values.yaml
@@ -1,6 +1,6 @@
 simple-service:
   application:
-    image: "bkimminich/juice-shop:v12.0.0"
+    image: "bkimminich/juice-shop:v18.0.0"
     port: 3000
     env:
       foo: bar


### PR DESCRIPTION
This seems to resolve resource usage issues and 500 errors from the 12.0.0 version. Tested resource usage, even after 100000+ requests at high concurrency never exceeded 320MiB with version 18.0.0.