### PR TITLE
fix: pin exact version of the docker image for chaotic-shop

### DIFF
--- a/charts/chaotic-shop/values.yaml
+++ b/charts/chaotic-shop/values.yaml
@@ -1,6 +1,6 @@
 simple-service:
   application:
-    image: anatol1988/chaotic-shop:latest
+    image: anatol1988/chaotic-shop@sha256:9929b75ec9db598c73535a85bd598be755459e7cc68bc7ef8ac6eed66bc68a80
     port: 5001
     resources:
       requests:


### PR DESCRIPTION
https://hub.docker.com/layers/anatol1988/chaotic-shop/main-9fb2ae/images/sha256-9929b75ec9db598c73535a85bd598be755459e7cc68bc7ef8ac6eed66bc68a80